### PR TITLE
Add Ruff workflow for formatting and linting Python files

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,94 @@
+name: Ruff Format and Lint
+
+on:
+  push:
+    branches: [ '*' ]
+    paths:
+      - '**.py'
+      - '**.pyi'
+  pull_request:
+    branches: [ '*' ]
+    paths:
+      - '**.py'
+      - '**.pyi'
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Ruff
+        run: pip install ruff==0.14.3
+
+      - name: Check for changes in supported files
+        id: file-changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # For PRs, check against the base branch
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            # For pushes, check against the previous commit
+            # Handle case where before might be empty (first commit)
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+            if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              # First commit or empty before, use HEAD~1 or HEAD
+              BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+            fi
+          fi
+          
+          # Check if any Python or ruff-supported files changed
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null | grep -E '\.(py|pyi)$' || true)
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No Python files changed, skipping Ruff"
+          fi
+
+      - name: Run Ruff Check (with auto-fix and import sorting)
+        if: steps.file-changes.outputs.has_changes == 'true'
+        run: |
+          ruff check --fix --select I .
+
+      - name: Run Ruff Format
+        if: steps.file-changes.outputs.has_changes == 'true'
+        run: |
+          ruff format .
+
+      - name: Check for changes after Ruff
+        if: steps.file-changes.outputs.has_changes == 'true'
+        id: verify-changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes
+        if: steps.file-changes.outputs.has_changes == 'true' && steps.verify-changes.outputs.changes_detected == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Apply Ruff formatting and import sorting [skip ci]"
+          git push
+

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -66,12 +66,12 @@ jobs:
       - name: Run Ruff Check (with auto-fix and import sorting)
         if: steps.file-changes.outputs.has_changes == 'true'
         run: |
-          ruff check --fix --select I .
+          ruff check --fix --select I $CHANGED_FILES
 
       - name: Run Ruff Format
         if: steps.file-changes.outputs.has_changes == 'true'
         run: |
-          ruff format .
+          ruff format $CHANGED_FILES
 
       - name: Check for changes after Ruff
         if: steps.file-changes.outputs.has_changes == 'true'

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
+          git add '*.py' '*.pyi'
           git commit -m "Apply Ruff formatting and import sorting [skip ci]"
           git push
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -83,12 +83,39 @@ jobs:
             echo "changes_detected=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit changes
+      - name: Check if branch is protected
         if: steps.file-changes.outputs.has_changes == 'true' && steps.verify-changes.outputs.changes_detected == 'true'
+        id: check-branch
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          # List of protected branches
+          PROTECTED_BRANCHES="main master production prod release"
+          
+          IS_PROTECTED=false
+          for protected in $PROTECTED_BRANCHES; do
+            if [ "$BRANCH_NAME" = "$protected" ]; then
+              IS_PROTECTED=true
+              break
+            fi
+          done
+          
+          echo "is_protected=$IS_PROTECTED" >> $GITHUB_OUTPUT
+          echo "Branch: $BRANCH_NAME"
+          echo "Is protected: $IS_PROTECTED"
+
+      - name: Commit changes
+        if: steps.file-changes.outputs.has_changes == 'true' && steps.verify-changes.outputs.changes_detected == 'true' && steps.check-branch.outputs.is_protected == 'false'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add '*.py' '*.pyi'
           git commit -m "Apply Ruff formatting and import sorting [skip ci]"
           git push
+
+      - name: Fail on protected branch with changes
+        if: steps.file-changes.outputs.has_changes == 'true' && steps.verify-changes.outputs.changes_detected == 'true' && steps.check-branch.outputs.is_protected == 'true'
+        run: |
+          echo "::error::Ruff formatting/linting changes detected on protected branch '${{ github.ref_name }}'"
+          echo "::error::Please run 'ruff format' and 'ruff check --fix --select I' locally and commit the changes"
+          exit 1
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Ruff
-        run: pip install ruff==0.14.3
+        run: pip install "ruff>=0.14.3,<1.0.0"
 
       - name: Check for changes in supported files
         id: file-changes


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically enforce Python code formatting and import sorting using Ruff. The workflow runs on every push and pull request affecting Python files, ensuring code style consistency and reducing manual formatting work.

**Automation of Python code formatting and linting:**

* Added a new workflow file `.github/workflows/ruff.yml` that installs Python and Ruff, checks for changes in Python files, and runs Ruff to auto-fix imports and format code.
* The workflow commits and pushes any formatting changes back to the repository if Ruff makes modifications.
* The workflow is triggered only when `.py` or `.pyi` files are changed, optimizing CI resources.

@JoshSchmucki Due to unknown reasons I haven’t been able to test this workflow. I’m assuming once it is merged to the main branch I’ll be able to test it, but I wanted to make sure that you are okay with that before doing it.